### PR TITLE
Change publish command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,8 +27,8 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: |
-            npm run build
-            zip -r boil-node-22.zip dist/boil.cjs -j
+            npm run build &&
+            zip -r boil-node-22.zip dist/boil.cjs -j &&
             gh release upload ${{github.event.release.tag_name}} boil-node-22.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release.yaml` to ensure the `gh release upload` command only runs if the preceding commands succeed.

## Changes
* Modify the `publish` step to chain commands with `&&`, ensuring `gh release upload` executes only if `npm run build` and `zip` commands are successful.