### PR TITLE
Change workflow to separate publish step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,10 +25,13 @@ jobs:
 
       - name: Create Release Pull Request
         uses: changesets/action@v1
-        with:
-          publish: |
-            npm run build &&
-            zip -r boil-node-22.zip dist/boil.cjs -j &&
-            gh release upload ${{github.event.release.tag_name}} boil-node-22.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        # Upload an artifact when a publish should happen.
+        run: |
+          npm run build
+          zip -r boil-node-22.zip dist/boil.cjs -j
+          gh release upload ${{github.event.release.tag_name}} boil-node-22.zip


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yaml` file to improve the release workflow by separating the creation of the release pull request and the publishing process.

## Changes
* Modify the `jobs:` section to move the publishing logic into a separate step named "Publish," which is conditionally executed based on the `hasChangesets` output. This improves clarity and ensures publishing only occurs when appropriate.