### PR TITLE
Fix issue on remote-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ A simple project scaffolding tool that generates project structures from hsfiles
 - Support for local files and remote URLs
 - Variable substitution with `{{variable}}` syntax
 - Interactive prompts for missing variables
-- Verbose output option
 - Easy installation and usage
 
 ## Installation
@@ -37,7 +36,7 @@ boil my-project ./templates/basic
 boil my-project https://raw.githubusercontent.com/datalek/boil/main/examples/minimal-js
 
 # Using remote runner
-curl -fsSL https://raw.githubusercontent.com/datalek/boil/main/remote.sh | bash -s -- my-project https://raw.githubusercontent.com/datalek/boil/main/examples/minimal-js 
+curl -fsSL https://raw.githubusercontent.com/datalek/boil/main/scripts/remote.sh | bash -s -- my-project https://raw.githubusercontent.com/datalek/boil/main/examples/minimal-js 
 ```
 
 ### Remote Runner
@@ -45,7 +44,7 @@ curl -fsSL https://raw.githubusercontent.com/datalek/boil/main/remote.sh | bash 
 For convenience, you can also use the remote runner script:
 
 ``` bash
-curl -fsSL https://raw.githubusercontent.com/datalek/boil/main/remote.sh | bash  -s -- <project-name> <template-path> 
+curl -fsSL https://raw.githubusercontent.com/datalek/boil/main/scripts/remote.sh | bash  -s -- <project-name> <template-path>
 ```
 
 ## Template Format

--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -10,4 +10,4 @@ curl -sL https://github.com/datalek/boil/releases/latest/download/boil-node-22.t
 
 # Extracting
 tar -xzf archive.tgz
-npx node boil.cjs "$@"
+npx node dist/boil.cjs "$@"


### PR DESCRIPTION
This pull request includes updates to the documentation and scripts for the project scaffolding tool `boil`. The changes improve clarity in the `README.md` file and update the script paths and execution commands for better functionality.

### Changes

* Remove the verbose output option from the feature list, reflecting current functionality.
* Update the remote runner script URL to point to the correct `scripts/remote.sh` path, ensuring accurate instructions for users.
* Modify the script to use `dist/boil.cjs` instead of `boil.cjs` for execution, aligning with the updated project structure.