### PR TITLE
Fix interactive input handling in remote script

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -10,4 +10,5 @@ curl -sL https://github.com/datalek/boil/releases/latest/download/boil-node-22.t
 
 # Extracting
 tar -xzf archive.tgz
-npx node dist/boil.cjs "$@"
+# Redirect stdin to tty for interactive input
+npx node dist/boil.cjs "$@" < /dev/tty


### PR DESCRIPTION
The remote script failed to handle interactive prompts when executed via `curl | bash` because stdin was occupied by the script content.

## Changes
- Redirect stdin to `/dev/tty` when executing `boil.cjs`