### PR TITLE
Change remote script to avoid changing working dir

### DIFF
--- a/scripts/remote.sh
+++ b/scripts/remote.sh
@@ -3,12 +3,11 @@
 set -e
 TEMP=$(mktemp -d)
 trap "rm -rf $TEMP" EXIT
-cd "$TEMP"
 
-# Downloading
-curl -sL https://github.com/datalek/boil/releases/latest/download/boil-node-22.tgz -o archive.tgz
-
+# Download and extract in temp (without changing working directory)
+curl -sL https://github.com/datalek/boil/releases/latest/download/boil-node-22.tgz -o "$TEMP/archive.tgz"
 # Extracting
-tar -xzf archive.tgz
+tar -xzf "$TEMP/archive.tgz" -C "$TEMP"
+
 # Redirect stdin to tty for interactive input
-npx node dist/boil.cjs "$@" < /dev/tty
+npx node "$TEMP/dist/boil.cjs" "$@" < /dev/tty


### PR DESCRIPTION
The remote script was creating project files in a temporary directory instead of the current working directory where the user invoked the command. This made the generated project inaccessible after script completion.

Modified the script to download and extract the boil binary in a temporary location while maintaining the original working directory for project generation.

## Changes
- Update the remote-run script to operate from original working directory