### PR TITLE
Fix release PR not triggering workflows

### DIFF
--- a/.changeset/fix-release-workflow-pat.md
+++ b/.changeset/fix-release-workflow-pat.md
@@ -1,0 +1,7 @@
+---
+"boil": patch
+---
+
+Fix release PR not triggering required workflows
+
+Switch from GITHUB_TOKEN to PAT_TOKEN in the release workflow so that PRs created by changesets/action trigger the pr-checks workflow.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
           commit: 'Publish Release'
           title: 'Publish Release'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
 
       - name: Set Job Outputs
         id: publish-output


### PR DESCRIPTION
## What's the focus of this PR?

PRs created by `changesets/action` using `GITHUB_TOKEN` don't trigger other workflows due to GitHub's security restrictions. This caused the release PR to be stuck because the required `pr-checks` workflow never ran.
This PR switches from `GITHUB_TOKEN` to `PAT_TOKEN` (a fine-grained Personal Access Token), which triggers workflows as expected.

## Show pictures of your visual changes

N/A - No visual changes.

## Instructions for Testing this PR

1. Merge this PR
2. Push a changeset to `main`
3. Verify the release PR is created and `pr-checks` workflow is triggered

## Checklist before requesting a review

- [x] My changes are about only one task or issue, if it does not exist I have created it.
- [x] I have committed only changes relevant to the task.
- [x] I have minimized the number of changes.
- [x] I have performed a self-review of my code.
- [ ] I have checked that CI/CD checks pass before requesting a review.
- [x] If documentation updates are needed, I have made them accordingly.